### PR TITLE
TeeInput compatibility with AWS SDK

### DIFF
--- a/lib/unicorn/tee_input.rb
+++ b/lib/unicorn/tee_input.rb
@@ -109,6 +109,11 @@ class Unicorn::TeeInput < Unicorn::StreamInput
     @tmp.rewind # Rack does not specify what the return value is here
   end
 
+	# Data source passed to AWS::S3::Object#write must respond to #read and #eof?
+  def eof?
+    super
+  end
+
 private
 
   # consumes the stream of the socket


### PR DESCRIPTION
With stack configuration nginx - Unicorn - Rack - Padrino - AWS SDK TeeInput object from request body as argument to AWS::S3::Object#write must have #eof? and #write in public interface.
