### PR TITLE
Rails Env should not be set by -E parameter

### DIFF
--- a/bin/unicorn_rails
+++ b/bin/unicorn_rails
@@ -56,7 +56,9 @@ op = OptionParser.new("", 24, '  ') do |opts|
 
   opts.on("-E", "--env RAILS_ENV",
           "use RAILS_ENV for defaults (default: development)") do |e|
-    ENV['RAILS_ENV'] = e
+    # This should not be set by -E
+    # -E is for setting the unicorn environment only..
+    #ENV['RAILS_ENV'] = e
   end
 
   opts.on("-D", "--daemonize", "run daemonized in the background") do |d|


### PR DESCRIPTION
I have found that the way this gem works, the unicorn rack env parameter will overwrite the rails environment name (`ENV["RAILS_ENV"]` variable).

Example:

```
RAILS_ENV=staging BUNDLE_GEMFILE=/var/www/giga_webapp-staging/current/Gemfile bundle exec unicorn_rails -c config/unicorn.rb -E deployment -D
```

Expect:
1. That the unicorn rack environment name is "deployment" (it is).
2. That the ENV["RAILS_ENV"] variable remains as "staging"

Get:
1. The ENV["RAILS_ENV"] variable is NOT staging; it is "deployment".
2. I am unable to reliably use the ENV["RAILS_ENV"] variable in the unicorn.rb config file, as a result.

I recommend that these two variables/environment names should not influence each other. 
1. In a multi stage configuration, a site's rails environment may change names in each different environment (eg: Production, Staging, Development... plus other possible). 
2. Unicorn, however, supports two rack environments ("deployment" or "development" or none). These have effects on what middleware is loaded, and effects on performance http://unicorn.bogomips.org/unicorn_1.html#rack-environment
3. Therefore, it must be possible to choose a RAILS_ENV independently of the unicorn rack environment.

The suggested code change, while it stops the RAILS_ENV variable from being overwritten, is not a full solution. I opened this pull request to discuss this issue and possible solutions, though.
