### PR TITLE
Remove bad bash command from init.sh example

### DIFF
--- a/examples/init.sh
+++ b/examples/init.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+
 # Example init script, this can be used with nginx, too,
 # since nginx and unicorn accept the same signals
 


### PR DESCRIPTION
It is considered bad form to include a `set -e` in a script destined for /etc/init.d.  If there is an error in the script, the boot process may hault if `set -e` is used.  See http://serverfault.com/a/416097/236060
