### PR TITLE
responses with the “text/html” type are always compressed

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -62,7 +62,7 @@ http {
   gzip_proxied any;
   gzip_min_length 500;
   gzip_disable "MSIE [1-6]\.";
-  gzip_types text/plain text/html text/xml text/css
+  gzip_types text/plain text/xml text/css
              text/comma-separated-values
              text/javascript application/x-javascript
              application/atom+xml;


### PR DESCRIPTION
Hey there,

Used your example config and noticed that it spits warning:

'nginx: [warn] duplicate MIME type "text/html" in /path/to/nginx.conf'

Digged around a bit and found that it is because there is no need to explicitly turn on compression for 'text/html'. It's always turned on by default.
