### PR TITLE
`unicorn upgrade` script resilience against exceptions

### DIFF
--- a/examples/init.sh
+++ b/examples/init.sh
@@ -45,7 +45,7 @@ restart|reload)
 	$CMD
 	;;
 upgrade)
-	if sig USR2 && sleep 2 && sig 0 && oldsig QUIT
+	if sig USR2 && sleep 2 && sig 0
 	then
 		n=$TIMEOUT
 		while test -s $old_pid && test $n -ge 0


### PR DESCRIPTION
This is actually a change proposal "by accident". But first, some background:

My server uses a standard version of this `init.sh` script. I found that executing `unicorn upgrade` often gives me problems. 

For example, it breaks my Capistrano deploy script to use `unicorn:upgrade` to deploy. This is a shame, since it's the correct command for Unicorn to pick up any code changes. But unicorn upgrade in the script fails with messages like:

```
sudo /etc/init.d/unicorn upgrade
Couldn't upgrade, starting 'export HOME=/home/deploy ; cd /var/www/my_app/current && /home/deploy/.rvm/wrappers/my_app/bundle exec unicorn -D -c /var/www/my_app/shared/config/unicorn.rb -E production' instead
master failed to start, check stderr log for details
```


And the stderror log:
```
E, [2016-06-07T09:03:27.517267 #27583] ERROR -- : reaped #<Process::Status: pid 27621 exit 1> exec()-ed
/var/www/my_app/shared/vendor/bundle/ruby/2.3.0/gems/unicorn-5.1.0/lib/unicorn/http_server.rb:195:in 
    `pid=': Already running on PID:27583 (or pid=/var/www/my_app/shared/tmp/pids/unicorn.pid is stale) 
    (ArgumentError)
```

I am proposing this change because I misread the documentation for the SIGNALS!
I thought that Unicorn itself sends a QUIT after all subprocesses has ended via SIG USR2.

So I made this change on a server, and it works! 


I just don't understand why, since reading the documentation again it says:
https://github.com/defunkt/unicorn/blob/d23d4713dc9ab9732c574f5aa34a4b6740b43164/SIGNALS#L35

> * USR2 - reexecute the running binary.  A separate QUIT
>  should be sent to the original process once the child is verified to
>  be up and running.

So clearly, I should send the QUIT signal.


My goal is to have a resilient, robust deployment, where unicorn picks up any code changes. 

Can you help me and enlighten me as to why this proposed change works?