### PR TITLE
Fix typo in comments about stderr_path at unicorn.conf.rb

### DIFF
--- a/examples/unicorn.conf.rb
+++ b/examples/unicorn.conf.rb
@@ -35,7 +35,7 @@ timeout 30
 pid "/path/to/app/shared/pids/unicorn.pid"
 
 # By default, the Unicorn logger will write to stderr.
-# Additionally, ome applications/frameworks log to stderr or stdout,
+# Additionally, some applications/frameworks log to stderr or stdout,
 # so prevent them from going to /dev/null when daemonized here:
 stderr_path "/path/to/app/shared/log/unicorn.stderr.log"
 stdout_path "/path/to/app/shared/log/unicorn.stdout.log"


### PR DESCRIPTION
I'd also will be very appreciated, if anybody answer me, why does unicorn have such default – `stderr`?
At least unicorn start/restart/stop log entries are considered as a reflection of a normal behavior and I supposed to find them in `stdout`.