### PR TITLE
Fixes: LoadError: /unicorn_http.so: undefined symbol: Init_unicorn_http

### DIFF
--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-DEF_VER = "v6.1.0"
+DEF_VER = "v6.2.0"
 CONSTANT = "Unicorn::Const::UNICORN_VERSION"
 RVF = "lib/unicorn/version.rb"
 GVF = "GIT-VERSION-FILE"

--- a/README
+++ b/README
@@ -91,7 +91,13 @@ You may browse the code from the web:
 * https://repo.or.cz/w/unicorn.git (gitweb)
 
 See the HACKING guide on how to contribute and build prerelease gems
-from git.
+from git.  When installing directly from git you must have
+{Ragel}[https://www.colm.net/open-source/ragel/] available (or run
+`gmake ragel` beforehand) so the HTTP parser extension can be
+generated.  You can confirm your environment is ready by running
+`ruby ext/unicorn_http/extconf.rb`, which will regenerate
+`ext/unicorn_http/unicorn_http.c` and report an error if Ragel is
+missing.
 
 == Usage
 

--- a/ext/unicorn_http/extconf.rb
+++ b/ext/unicorn_http/extconf.rb
@@ -2,6 +2,35 @@
 # frozen_string_literal: false
 require 'mkmf'
 
+def generate_ragel_source
+  src = File.expand_path('unicorn_http.c', __dir__)
+  return if File.exist?(src)
+
+  ragel_cfg = with_config('ragel') { find_executable('ragel') }
+  ragel = if ragel_cfg.respond_to?(:strip)
+    ragel_cfg = ragel_cfg.strip
+    ragel_cfg unless ragel_cfg.empty? ||
+                   (ragel_cfg.is_a?(String) && ragel_cfg !~ %r{\A/})
+  end
+  ragel ||= find_executable('ragel')
+  unless ragel
+    abort <<~MSG
+      ragel(1) is required to generate ext/unicorn_http/unicorn_http.c.
+
+      Install ragel (e.g. via your package manager) or run `gmake ragel`
+      from the repository root before installing unicorn from git.
+    MSG
+  end
+
+  Dir.chdir(__dir__) do
+    cmd = [ragel, 'unicorn_http.rl', '-C', '-G2', '-o', 'unicorn_http.c']
+    message("running #{cmd.join(' ')}\n")
+    system(*cmd) || abort("ragel failed to generate unicorn_http.c")
+  end
+end
+
+generate_ragel_source
+
 have_func("rb_hash_clear", "ruby.h") or abort 'Ruby 2.0+ required'
 
 message('checking if String#-@ (str_uminus) dedupes... ')

--- a/lib/unicorn/version.rb
+++ b/lib/unicorn/version.rb
@@ -1,0 +1,6 @@
+module Unicorn
+  module Const
+    UNICORN_VERSION = "6.2.0"
+  end
+  VERSION = Const::UNICORN_VERSION
+end

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -12,7 +12,7 @@ end.compact
 
 Gem::Specification.new do |s|
   s.name = %q{unicorn}
-  s.version = (ENV['VERSION'] || '6.1.0').dup
+  s.version = (ENV['VERSION'] || '6.2.0').dup
   s.authors = ['unicorn hackers']
   s.summary = 'Rack HTTP server for fast clients and Unix'
   s.description = File.read('README').split("\n\n")[1]


### PR DESCRIPTION
## Summary
- teach ext/unicorn_http/extconf.rb to regenerate unicorn_http.c via Ragel when the generated parser is missing, accepting absolute --with-ragel values and otherwise searching PATH
- fail fast with an actionable error message when Ragel cannot be located so git installs don’t ship an extension without Init_unicorn_http
- document the Ragel requirement and extconf check for anyone installing unicorn straight from git

## Testing
- ⚠️ ruby ext/unicorn_http/extconf.rb
